### PR TITLE
Add Claude Code settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ node_modules
 
 # Qiita CLI configuration (contains API token)
 .qiita-config/
+
+###############################################################################
+# Claude Code
+###############################################################################
+# Personal preferences and experimental settings that vary per developer
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to .gitignore to exclude personal Claude Code settings from version control

## Details
Claude Codeの個人設定ファイル（`.claude/settings.local.json`）をバージョン管理から除外するように.gitignoreを更新しました。このファイルには開発者ごとに異なる個人設定や実験的な設定が含まれるため、リポジトリにコミットすべきではありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)